### PR TITLE
Use ambient colour, specular colour, and specular exponent

### DIFF
--- a/vcg/complex/base.h
+++ b/vcg/complex/base.h
@@ -539,14 +539,20 @@ template < class FaceType>    bool FaceVectorHasPerFaceQuality(const std::vector
 template < class FaceType>    bool FaceVectorHasFFAdjacency   (const std::vector<FaceType> &) {  return FaceType::HasFFAdjacency(); }
 template < class FaceType>    bool FaceVectorHasFEAdjacency   (const std::vector<FaceType> &) {  return FaceType::HasFEAdjacency(); }
 template < class FaceType>    bool FaceVectorHasFVAdjacency   (const std::vector<FaceType> &) {  return FaceType::HasFVAdjacency(); }
-template < class FaceType>    bool FaceVectorHasPerFaceCurvatureDir   (const std::vector<FaceType> &) {  return FaceType::HasCurvatureDir(); }
+template < class FaceType>    bool FaceVectorHasPerFaceCurvatureDir     (const std::vector<FaceType> &) { return FaceType::HasCurvatureDir    (); }
+template < class FaceType>    bool FaceVectorHasPerFaceSpecularColor    (const std::vector<FaceType> &) { return FaceType::HasSpecularColor   (); }
+template < class FaceType>    bool FaceVectorHasPerFaceAmbientColor     (const std::vector<FaceType> &) { return FaceType::HasAmbientColor    (); }
+template < class FaceType>    bool FaceVectorHasPerFaceSpecularExponent (const std::vector<FaceType> &) { return FaceType::HasSpecularExponent(); }
 
-template < class TriMeshType> bool HasPerFaceFlags       (const TriMeshType &m) { return tri::FaceVectorHasPerFaceFlags       (m.face); }
-template < class TriMeshType> bool HasPerFaceNormal      (const TriMeshType &m) { return tri::FaceVectorHasPerFaceNormal      (m.face); }
-template < class TriMeshType> bool HasPerFaceColor       (const TriMeshType &m) { return tri::FaceVectorHasPerFaceColor       (m.face); }
-template < class TriMeshType> bool HasPerFaceMark        (const TriMeshType &m) { return tri::FaceVectorHasPerFaceMark        (m.face); }
-template < class TriMeshType> bool HasPerFaceQuality     (const TriMeshType &m) { return tri::FaceVectorHasPerFaceQuality     (m.face); }
-template < class TriMeshType> bool HasPerFaceCurvatureDir(const TriMeshType &m) { return tri::FaceVectorHasPerFaceCurvatureDir(m.face); }
+template < class TriMeshType> bool HasPerFaceFlags            (const TriMeshType &m) { return tri::FaceVectorHasPerFaceFlags           (m.face); }
+template < class TriMeshType> bool HasPerFaceNormal           (const TriMeshType &m) { return tri::FaceVectorHasPerFaceNormal          (m.face); }
+template < class TriMeshType> bool HasPerFaceColor            (const TriMeshType &m) { return tri::FaceVectorHasPerFaceColor           (m.face); }
+template < class TriMeshType> bool HasPerFaceMark             (const TriMeshType &m) { return tri::FaceVectorHasPerFaceMark            (m.face); }
+template < class TriMeshType> bool HasPerFaceQuality          (const TriMeshType &m) { return tri::FaceVectorHasPerFaceQuality         (m.face); }
+template < class TriMeshType> bool HasPerFaceCurvatureDir     (const TriMeshType &m) { return tri::FaceVectorHasPerFaceCurvatureDir    (m.face); }
+template < class TriMeshType> bool HasPerFaceSpecularColor    (const TriMeshType &m) { return tri::FaceVectorHasPerFaceSpecularColor   (m.face); }
+template < class TriMeshType> bool HasPerFaceAmbientColor     (const TriMeshType &m) { return tri::FaceVectorHasPerFaceAmbientColor    (m.face); }
+template < class TriMeshType> bool HasPerFaceSpecularExponent (const TriMeshType &m) { return tri::FaceVectorHasPerFaceSpecularExponent(m.face); }
 template < class TriMeshType> bool HasFFAdjacency   (const TriMeshType &m) { return tri::FaceVectorHasFFAdjacency   (m.face); }
 template < class TriMeshType> bool HasEEAdjacency   (const TriMeshType &m) { return tri::EdgeVectorHasEEAdjacency   (m.edge); }
 template < class TriMeshType> bool HasFEAdjacency   (const TriMeshType &m) { return tri::FaceVectorHasFEAdjacency   (m.face); }

--- a/vcg/simplex/face/base.h
+++ b/vcg/simplex/face/base.h
@@ -99,7 +99,7 @@ public:
         DELETED     = 0x00000001,		// Face is deleted from the mesh
         NOTREAD     = 0x00000002,		// Face of the mesh is not readable
         NOTWRITE    = 0x00000004,		// Face of the mesh is not writable
-    VISITED     = 0x00000010,		// Face has been visited. Usualy this is a per-algorithm used bit.
+        VISITED     = 0x00000010,		// Face has been visited. Usualy this is a per-algorithm used bit.
         SELECTED    = 0x00000020,		// Face is selected. Algorithms should try to work only on selected face (if explicitly requested)
         // Border _flags, it is assumed that BORDERi = BORDER0<<i
         BORDER0     = 0x00000040,
@@ -121,7 +121,7 @@ public:
         FAUX012     = FAUX0 | FAUX1 | FAUX2 ,
         // First user bit
         USER0       = 0x00200000
-            };
+    };
 
 
     ///  checks if the Face is deleted

--- a/vcg/simplex/face/component.h
+++ b/vcg/simplex/face/component.h
@@ -75,6 +75,12 @@ public:
   typedef ColorType WedgeColorType;
   ColorType &C()       { static ColorType dumcolor(vcg::Color4b::White);  assert(0); return dumcolor; }
   ColorType cC() const { static ColorType dumcolor(vcg::Color4b::White);  assert(0); return dumcolor; }
+  ColorType &Amb()       { static ColorType dumcolor(vcg::Color4b::White);  assert(0); return dumcolor; }
+  ColorType cAmb() const { static ColorType dumcolor(vcg::Color4b::White);  assert(0); return dumcolor; }
+  ColorType &Spec()       { static ColorType dumcolor(vcg::Color4b::White);  assert(0); return dumcolor; }
+  ColorType cSpec() const { static ColorType dumcolor(vcg::Color4b::White);  assert(0); return dumcolor; }
+  float     &Ns()       { static float dumfloat; assert(0); return dumfloat; }
+  float     cNs() const { static float dumfloat; assert(0); return dumfloat; }
   WedgeColorType &WC(const int)       { static ColorType dumcolor(vcg::Color4b::White);  assert(0); return dumcolor; }
   WedgeColorType cWC(const int) const { static ColorType dumcolor(vcg::Color4b::White);  assert(0); return dumcolor; }
   QualityType &Q()       { static QualityType dummyQuality(0);  assert(0); return dummyQuality; }
@@ -83,6 +89,9 @@ public:
   Quality3Type cQ3() const { static Quality3Type dummyQuality3(0,0,0);  assert(0); return dummyQuality3; }
 
   static bool HasColor()   { return false; }
+  static bool HasAmbientColor()   { return false; }
+  static bool HasSpecularColor()   { return false; }
+  static bool HasSpecularExponent()   { return false; }
   static bool HasQuality()   { return false; }
   static bool HasQuality3()   { return false; }
   static bool HasMark()   { return false; }
@@ -382,16 +391,77 @@ private:
   WedgeColorType _color[3];
 };
 
+template <class A, class T> class AmbientColor: public T {
+public:
+  typedef A ColorType;
+  AmbientColor():_color(vcg::Color4b::White) {}
+  ColorType &Amb()       { return _color; }
+  ColorType cAmb() const { return _color; }
+  template <class RightValueType>
+  void ImportData(const RightValueType & rightF){
+    if(rightF.IsAmbientColorEnabled()) Amb() = rightF.cAmb();
+    T::ImportData(rightF);
+  }
+
+  static bool HasAmbientColor()   { return true; }
+  static void Name(std::vector<std::string> & name){name.push_back(std::string("AmbientColor"));T::Name(name);}
+
+private:
+  ColorType _color;
+};
+
+template <class A, class T> class SpecularColor: public T {
+public:
+  typedef A ColorType;
+  SpecularColor():_color(vcg::Color4b::White) {}
+  ColorType &Spec()       { return _color; }
+  ColorType cSpec() const { return _color; }
+  template <class RightValueType>
+  void ImportData(const RightValueType & rightF){
+    if(rightF.IsSpecularColorEnabled()) Spec() = rightF.cSpec();
+    T::ImportData(rightF);
+  }
+
+  static bool HasSpecularColor()   { return true; }
+  static void Name(std::vector<std::string> & name){name.push_back(std::string("SpecularColor"));T::Name(name);}
+
+private:
+  ColorType _color;
+};
+
+template <class T> class SpecularExponent: public T {
+public:
+  SpecularExponent():_ns(0.0) {}
+  inline float &Ns()       { return _ns; }
+  inline float cNs() const { return _ns; }
+  template <class RightValueType>
+  void ImportData(const RightValueType & rightF){
+    if(rightF.IsSpecularExponentEnabled()) Ns() = rightF.cNs();
+    T::ImportData(rightF);
+  }
+
+  static bool HasSpecularExponent()   { return true; }
+  static void Name(std::vector<std::string> & name){name.push_back(std::string("SpecularExponent"));T::Name(name);}
+
+private:
+  float _ns;
+};
+
 template <class T> class WedgeColor4b: public WedgeColor<vcg::Color4b, T> {
 public: static void Name(std::vector<std::string> & name){name.push_back(std::string("WedgeColor4b"));T::Name(name);}
 };
 template <class T> class WedgeColor4f: public WedgeColor<vcg::Color4f, T> {
 public: static void Name(std::vector<std::string> & name){name.push_back(std::string("WedgeColor4f"));T::Name(name);}
 };
-template <class T> class Color4b: public Color<vcg::Color4b, T> { public:
+template <class T> class Color4b: public Color<vcg::Color4b, T> {
 public: static void Name(std::vector<std::string> & name){name.push_back(std::string("Color4b"));T::Name(name);}
 };
-
+template <class T> class AmbientColor4b: public AmbientColor<vcg::Color4b, T> {
+public: static void Name(std::vector<std::string> & name){name.push_back(std::string("AmbientColor4b"));T::Name(name);}
+};
+template <class T> class SpecularColor4b: public SpecularColor<vcg::Color4b, T> {
+public: static void Name(std::vector<std::string> & name){name.push_back(std::string("SpecularColor4b"));T::Name(name);}
+};
 /*-------------------------- Quality  ----------------------------------*/
 template <class A, class T> class Quality: public T {
 public:

--- a/wrap/io_trimesh/import_obj.h
+++ b/wrap/io_trimesh/import_obj.h
@@ -112,7 +112,10 @@ namespace vcg {
                     std::vector<int> t;
                     int tInd;
                     bool  edge[3];// useless if the face is a polygon, no need to have variable length array
-                    Color4b c;
+                    Color4b c; // diffuse color
+                    Color4b a; // ambient color
+                    Color4b s; // spectral color
+                    float ns;  // spectral exponent
                 };
 
                 struct ObjEdge
@@ -264,6 +267,9 @@ namespace vcg {
                     short currentMaterialIdx = 0;			// index of current material into materials vector
                     Color4b currentColor=Color4b::LightGray;	// we declare this outside code block since other
                     // triangles of this face will share the same color
+                    Color4b currentAmbient = Color4b::LightGray;
+                    Color4b currentSpecular = Color4b::LightGray;
+                    float currentNs = 0.0;
 
                     Material defaultMaterial;					// default material: white
                     materials.push_back(defaultMaterial);
@@ -460,8 +466,12 @@ namespace vcg {
                                     }
 
 
-                                    if( oi.mask & vcg::tri::io::Mask::IOM_FACECOLOR) // assigning face color
+                                    if( oi.mask & vcg::tri::io::Mask::IOM_FACECOLOR) { // assigning face color
                                         ff.c = currentColor;
+                                        ff.a = currentAmbient;
+                                        ff.s = currentSpecular;
+                                        ff.ns = currentNs;
+                                    }
 
                                     ++numTriangles;
                                     indexedFaces.push_back(ff);
@@ -584,7 +594,12 @@ namespace vcg {
                                         }
 
                                         // assigning face color
-                                        if( oi.mask & vcg::tri::io::Mask::IOM_FACECOLOR) ff.c = currentColor;
+                                        if( oi.mask & vcg::tri::io::Mask::IOM_FACECOLOR) {
+                                            ff.c = currentColor;
+                                            ff.a = currentAmbient;
+                                            ff.s = currentSpecular;
+                                            ff.ns = currentNs;
+                                        }
 
                                         ++numTriangles;
                                         indexedFaces.push_back(ff);
@@ -611,12 +626,11 @@ namespace vcg {
                                     {
                                         currentMaterialIdx = i;
                                         Material &material = materials[currentMaterialIdx];
-                                        Point3f diffuseColor = material.Kd;
-                                        unsigned char r			= (unsigned char) (diffuseColor[0] * 255.0);
-                                        unsigned char g			= (unsigned char) (diffuseColor[1] * 255.0);
-                                        unsigned char b			= (unsigned char) (diffuseColor[2] * 255.0);
-                                        unsigned char alpha = (unsigned char) (material.Tr  * 255.0);
-                                        currentColor= Color4b(r, g, b, alpha);
+
+                                        currentColor = toIntColor(material.Kd, material.Tr);
+                                        currentAmbient = toIntColor(material.Ka, 1.0);
+                                        currentSpecular = toIntColor(material.Ks, 1.0);
+                                        currentNs = material.Ns;
                                         found = true;
                                     }
                                     ++i;
@@ -700,9 +714,16 @@ namespace vcg {
 
                         if (HasPerFaceNormal(m))
                         {
-                            if (((oi.mask & vcg::tri::io::Mask::IOM_FACECOLOR) != 0) && (HasPerFaceColor(m)))
+                            if (((oi.mask & vcg::tri::io::Mask::IOM_FACECOLOR) != 0))
                             {
-                                m.face[i].C() = indexedFaces[i].c;
+                                if (HasPerFaceColor(m))
+                                    m.face[i].C() = indexedFaces[i].c;
+                                if (HasPerFaceAmbientColor(m))
+                                    m.face[i].Amb() = indexedFaces[i].a;
+                                if (HasPerFaceSpecularExponent(m))
+                                    m.face[i].Ns() = indexedFaces[i].ns;
+                                if (HasPerFaceSpecularColor(m))
+                                    m.face[i].Spec() = indexedFaces[i].s;
                             }
 
                             if (((oi.mask & vcg::tri::io::Mask::IOM_WEDGNORMAL) != 0) && (HasPerWedgeNormal(m)))
@@ -1051,6 +1072,15 @@ namespace vcg {
                     bool ret=LoadMask(filename, oi);
                     mask= oi.mask;
                     return ret;
+                }
+
+                static Color4b toIntColor(Point3f rgb, float a)
+                {
+                    unsigned char r			= (unsigned char) (rgb[0] * 255.0);
+                    unsigned char g			= (unsigned char) (rgb[1] * 255.0);
+                    unsigned char b			= (unsigned char) (rgb[2] * 255.0);
+                    unsigned char alpha     = (unsigned char) (a  * 255.0);
+                    return Color4b(r, g, b, alpha);
                 }
 
                 static bool LoadMaterials(const char * filename, std::vector<Material> &materials, std::vector<std::string> &textures)

--- a/wrap/io_trimesh/io_material.h
+++ b/wrap/io_trimesh/io_material.h
@@ -96,24 +96,32 @@ namespace io {
 		inline static int CreateNewMaterial(SaveMeshType &m, std::vector<Material> &materials, unsigned int index, FaceIterator &fi)
 		{			
 			Point3f diffuse(1,1,1);
-      float Transp = 1;
-      if(HasPerFaceColor(m)){
-        diffuse = Point3f((float)((*fi).C()[0])/255.0f,(float)((*fi).C()[1])/255.0f,(float)((*fi).C()[2])/255.0f);//diffuse
-			  Transp = (float)((*fi).C()[3])/255.0f;//alpha
-      }
-			
-			int illum = 2; //default not use Ks!
-			float ns = 0.0; //default
+            Point3f ambient(1,1,1);
+            Point3f specular(1,1,1);
+            float specularExponent = 0.0;
+            float Transp = 1;
+            int illumination = 2;
+
+            if(HasPerFaceColor(m)){
+                diffuse = Point3f((float)((*fi).C()[0])/255.0f,(float)((*fi).C()[1])/255.0f,(float)((*fi).C()[2])/255.0f);//diffuse
+                Transp = (float)((*fi).C()[3])/255.0f;//alpha
+            }
+            if(HasPerFaceAmbientColor(m))
+                ambient = Point3f((float)((*fi).Amb()[0])/255.0f,(float)((*fi).Amb()[1])/255.0f,(float)((*fi).Amb()[2])/255.0f);
+            if(HasPerFaceSpecularColor(m))
+                specular = Point3f((float)((*fi).Spec()[0])/255.0f,(float)((*fi).Spec()[1])/255.0f,(float)((*fi).Spec()[2])/255.0f);
+            if(HasPerFaceSpecularExponent(m))
+                specularExponent = (*fi).Ns();
 
 			Material mtl;
 
 			mtl.index = index;//index of materials
-			mtl.Ka = Point3f(0.2f,0.2f,0.2f);//ambient
-			mtl.Kd = diffuse;//diffuse
-			mtl.Ks = Point3f(1.0f,1.0f,1.0f);//specular
-			mtl.Tr = Transp;//alpha
-			mtl.Ns = ns;
-			mtl.illum = illum;//illumination
+            mtl.Ka = ambient;
+            mtl.Kd = diffuse;
+            mtl.Ks = specular;
+            mtl.Tr = Transp;
+            mtl.Ns = specularExponent;
+            mtl.illum = illumination;
 			
 			if(m.textures.size() && (*fi).WT(0).n() >=0 ) 
 				mtl.map_Kd = m.textures[(*fi).WT(0).n()];


### PR DESCRIPTION
Previously these properties were being parsed in the various importers/exporters that support them, but not persisted in the main data structure (as the diffuse colour is). This commit fixes that, and makes use of these values in the OBJ importer and `wrap/io_trimesh/io_material.h`.

To use this feature, add `face::AmbientColor4b`, `face::SpecularColor4b`, and `face::SpecularExponent` to your face type.

Let me know if you have any questions or concerns.