### PR TITLE
Add material attributes in OBJ importer

### DIFF
--- a/wrap/io_trimesh/export_obj.h
+++ b/wrap/io_trimesh/export_obj.h
@@ -129,8 +129,8 @@ public:
     int current = 0;
     int totalPrimitives = m.vn+m.fn;
 
-    typename SaveMeshType::template PerMeshAttributeHandle<std::vector<Material>> materialsHandle =
-            vcg::tri::Allocator<SaveMeshType>::template FindPerMeshAttribute<std::vector<Material>>(m, "materials");
+    typename SaveMeshType::template PerMeshAttributeHandle<std::vector<Material> > materialsHandle =
+            vcg::tri::Allocator<SaveMeshType>::template FindPerMeshAttribute<std::vector<Material> >(m, "materials");
 
     std::string fn(filename);
     int LastSlash=fn.size()-1;

--- a/wrap/io_trimesh/export_obj.h
+++ b/wrap/io_trimesh/export_obj.h
@@ -28,6 +28,7 @@
 
 #include <wrap/callback.h>
 #include <wrap/io_trimesh/io_mask.h>
+#include <wrap/io_trimesh/io_material.h>
 #include <iostream>
 #include <fstream>
 #include <map>

--- a/wrap/io_trimesh/export_obj.h
+++ b/wrap/io_trimesh/export_obj.h
@@ -205,7 +205,7 @@ public:
     {
       if((mask & Mask::IOM_FACECOLOR) || (mask & Mask::IOM_WEDGTEXCOORD) || (mask & Mask::IOM_VERTTEXCOORD))
       {
-        int index = Materials<SaveMeshType>::CreateNewMaterial(m,materialVec,material_num,fi);
+        int index = (*fi).mInd;
 
         if(index == (int)materialVec.size())//inserts a new element material
         {

--- a/wrap/io_trimesh/import_obj.h
+++ b/wrap/io_trimesh/import_obj.h
@@ -256,8 +256,8 @@ namespace vcg {
                         return E_CANTOPEN;
                     }
 
-                    typename OpenMeshType::template PerMeshAttributeHandle<std::vector<Material>> materialsHandle =
-                            vcg::tri::Allocator<OpenMeshType>:: template GetPerMeshAttribute<std::vector<Material>>(m, std::string("materials"));
+                    typename OpenMeshType::template PerMeshAttributeHandle<std::vector<Material> > materialsHandle =
+                            vcg::tri::Allocator<OpenMeshType>:: template GetPerMeshAttribute<std::vector<Material> >(m, std::string("materials"));
                     typename OpenMeshType::template PerFaceAttributeHandle<int> mIndHandle =
                             vcg::tri::Allocator<OpenMeshType>:: template GetPerFaceAttribute<int>(m, std::string("mInd"));
                     std::vector<Material>&	materials = materialsHandle();  // materials vector

--- a/wrap/io_trimesh/import_obj.h
+++ b/wrap/io_trimesh/import_obj.h
@@ -51,6 +51,8 @@ namespace vcg {
             template <class OpenMeshType>
             class ImporterOBJ
             {
+            private:
+                std::vector<Material> materials;
             public:
                 static int &MRGBLineCount(){static int _MRGBLineCount=0; return _MRGBLineCount;}
 
@@ -113,6 +115,7 @@ namespace vcg {
                     int tInd;
                     bool  edge[3];// useless if the face is a polygon, no need to have variable length array
                     Color4b c;
+                    int mInd;
                 };
 
                 struct ObjEdge
@@ -254,7 +257,9 @@ namespace vcg {
                         stream.close();
                         return E_CANTOPEN;
                     }
-                    std::vector<Material>	materials;  // materials vector
+                    typename OpenMeshType::template PerMeshAttributeHandle<std::vector<Material>> hMaterial =
+                            vcg::tri::Allocator<OpenMeshType>:: template GetPerMeshAttribute<std::vector<Material>>(m, std::string("materials"));
+                    std::vector<Material>	materials = hMaterial();  // materials vector
                     std::vector<ObjTexCoord>	texCoords;  // texture coordinates
                     std::vector<CoordType>  normals;		// vertex normals
                     std::vector<ObjIndexedFace> indexedFaces;
@@ -584,6 +589,8 @@ namespace vcg {
 
                                         // assigning face color
                                         if( oi.mask & vcg::tri::io::Mask::IOM_FACECOLOR) ff.c = currentColor;
+
+                                        ff.mInd = currentMaterialIdx;
 
                                         ++numTriangles;
                                         indexedFaces.push_back(ff);


### PR DESCRIPTION
This is a redo of #5 that uses a per-mesh attribute `"materials"` on the given mesh and a per-face attribute `"mInd"` on each face of the mesh to store material properties instead of components.

This ensures that previously discarded properties, such as ambient color and specular values, are persisted on import and written on export.

Let me know if you see any problems, or have any questions at all.

Thanks!