### PR TITLE
Properly initialize default material in OBJ importer

### DIFF
--- a/wrap/io_trimesh/import_obj.h
+++ b/wrap/io_trimesh/import_obj.h
@@ -265,7 +265,16 @@ namespace vcg {
                     Color4b currentColor=Color4b::LightGray;	// we declare this outside code block since other
                     // triangles of this face will share the same color
 
-                    Material defaultMaterial;					// default material: white
+                    // Create a default material
+                    Material defaultMaterial;
+                    defaultMaterial.index = currentMaterialIdx;
+                    defaultMaterial.Ka = Point3f(0.2, 0.2, 0.2);
+                    defaultMaterial.Kd = Point3f(currentColor[0] / 255, currentColor[1] / 255, currentColor[2] / 255);
+                    defaultMaterial.Tr = currentColor[3] / 255;
+                    defaultMaterial.Ks = Point3f(1, 1, 1);
+                    defaultMaterial.Ns = 0;
+                    defaultMaterial.illum = 2;
+                    defaultMaterial.map_Kd = "";
                     materials.push_back(defaultMaterial);
 
                     int numVertices  = 0;  // stores the number of vertices been read till now

--- a/wrap/io_trimesh/import_obj.h
+++ b/wrap/io_trimesh/import_obj.h
@@ -269,8 +269,8 @@ namespace vcg {
                     Material defaultMaterial;
                     defaultMaterial.index = currentMaterialIdx;
                     defaultMaterial.Ka = Point3f(0.2, 0.2, 0.2);
-                    defaultMaterial.Kd = Point3f(currentColor[0] / 255, currentColor[1] / 255, currentColor[2] / 255);
-                    defaultMaterial.Tr = currentColor[3] / 255;
+                    defaultMaterial.Kd = Point3f(currentColor[0] / 255.0f, currentColor[1] / 255.0f, currentColor[2] / 255.0f);
+                    defaultMaterial.Tr = currentColor[3] / 255.0f;
                     defaultMaterial.Ks = Point3f(1, 1, 1);
                     defaultMaterial.Ns = 0;
                     defaultMaterial.illum = 2;


### PR DESCRIPTION
Currently a default material is added to the list of materials in the OBJ importer as a fallback for faces that have no material. However, that material is never instantiated, so it is filled with garbage values. This commit adds the default light grey colour and defaults from `io_material.h`.