### PR TITLE
No return statement in function returning non-void 

### DIFF
--- a/wrap/gl/gl_mesh_attributes_multi_viewer_bo_manager.h
+++ b/wrap/gl/gl_mesh_attributes_multi_viewer_bo_manager.h
@@ -905,6 +905,7 @@ namespace vcg
             bool isthereaquadview = false;
             for(typename ViewsMap::const_iterator it = _perviewreqatts.begin();it != _perviewreqatts.end();++it)
                 isthereaquadview = (it->second._intatts[size_t(PR_WIREFRAME_EDGES)][INT_ATT_NAMES::ATT_VERTPOSITION]) || isthereaquadview;
+            return isthereaquadview;
         }
 
 


### PR DESCRIPTION
Method NotThreadSafeGLMeshAttributesMultiViewerBOManager::isThereAnEdgesView returns not value despite the fact it must return a boolean. I found this when compiling under Linux.