### PR TITLE
std::binder2nd and std::binder1st deprecated

### DIFF
--- a/eigenlib/Eigen/src/Core/Functors.h
+++ b/eigenlib/Eigen/src/Core/Functors.h
@@ -969,6 +969,7 @@ template<typename T>
 struct functor_traits<std::not_equal_to<T> >
 { enum { Cost = 1, PacketAccess = false }; };
 
+#if(__cplusplus < 201103L)
 template<typename T>
 struct functor_traits<std::binder2nd<T> >
 { enum { Cost = functor_traits<T>::Cost, PacketAccess = false }; };
@@ -976,6 +977,7 @@ struct functor_traits<std::binder2nd<T> >
 template<typename T>
 struct functor_traits<std::binder1st<T> >
 { enum { Cost = functor_traits<T>::Cost, PacketAccess = false }; };
+#endif
 
 template<typename T>
 struct functor_traits<std::unary_negate<T> >


### PR DESCRIPTION
std::binder2nd and std::binder1st are deprecated in  the 2011 C++ Language Standard. This generates useless warnings like : 
```
In file included from ../../../vcglib/eigenlib/Eigen/Core:276:0,
                 from ../../../vcglib/vcg/math/matrix44.h:33,
                 from filterparameter.cpp:28:
../../../vcglib/eigenlib/Eigen/src/Core/Functors.h:977:28: warning: ‘template<class _Operation> class std::binder1st’ is deprecated [-Wdeprecated-declarations]
 struct functor_traits<std::binder1st<T> >
```
The fix simply adds ```#if(__cplusplus < 201103L)``` and ```#end``` between template declaration.

Plateform used : Linux terminus 4.4.0-57-generic #78-Ubuntu SMP Fri Dec 9 23:50:32 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux