### PR TITLE
Replacing Proj() with glProject(), in order to complete the changes o…

### DIFF
--- a/wrap/gl/pick.h
+++ b/wrap/gl/pick.h
@@ -108,7 +108,7 @@ public:
     for(size_t i=0;i<m.face.size();++i) if(!m.face[i].IsD())
     {
       CoordType bary = vcg::Barycenter(m.face[i]);
-      CoordType bz = Proj(M, viewportF,bary);
+      CoordType bz = glProject(M, viewportF,bary);
 
       if(bz[2]<bzmin && reg.IsIn(bz))
       {
@@ -131,7 +131,7 @@ public:
 
     for(size_t i=0;i<m.vert.size();++i) if(!m.vert[i].IsD())
     {
-      CoordType bz = Proj(M, viewportF,m.vert[i].P());
+      CoordType bz = glProject(M, viewportF,m.vert[i].P());
       if(bz[2]<bzmin && reg.IsIn(bz))
       {
         bzmin=bz[2];


### PR DESCRIPTION
I ran into the following error when trying to compile Meshlab:
../../../../vcglib/wrap/gl/pick.h:134:26: error: ‘Proj’ was not declared in this scope

And when I understand the issue correctly, this is because ‘Proj’ was replaced with ‘glProject’ in commit 607ffe778f10b6c79cb5972d6e52710e40c30c57. However, some pieces of the code continued to use ‘Proj’.