### PR TITLE
Don't assign MTL ambient map value to diffuse map

### DIFF
--- a/wrap/io_trimesh/import_obj.h
+++ b/wrap/io_trimesh/import_obj.h
@@ -1057,7 +1057,7 @@ namespace vcg {
                                 //currentMaterial.bSpecular = (illumination == 2);
                                 currentMaterial.illum = illumination;
                             }
-                            else if( (header.compare("map_Kd")==0)	|| (header.compare("map_Ka")==0) ) // texture name
+                            else if(header.compare("map_Kd")==0) // texture name
                             {
 								std::string textureName;
                                 if (tokens.size() < 2)
@@ -1065,7 +1065,7 @@ namespace vcg {
 								else if (tokens.size() == 2)
 									textureName = tokens[1]; //play it safe
 								else
-									textureName = line.substr(7); //get everything after "map_Kd " or "map_Ka "
+                                    textureName = line.substr(7); //get everything after "map_Kd "
 
                                 currentMaterial.map_Kd=textureName;
 

--- a/wrap/io_trimesh/import_obj.h
+++ b/wrap/io_trimesh/import_obj.h
@@ -1065,7 +1065,7 @@ namespace vcg {
 								else if (tokens.size() == 2)
 									textureName = tokens[1]; //play it safe
 								else
-                                    textureName = line.substr(7); //get everything after "map_Kd "
+									textureName = line.substr(7); //get everything after "map_Kd "
 
                                 currentMaterial.map_Kd=textureName;
 


### PR DESCRIPTION
This fixes a bug in which a `map_Ka` statement appears after a `map_Kd`, in which case the former will be assigned as the diffuse map of the imported mesh. For example, in an `MTL` of the form:
```mtl
map_Kd a_diffuse_map.png
map_Ka an_ambient_map.png
```
`an_ambient_map.png` will be assigned to the `currentMaterial`'s `map_Kd`, when it should be `a_diffuse_map.png`.