### PR TITLE
Support face types without normals in AdvancingFront

### DIFF
--- a/vcg/complex/algorithms/create/advancing_front.h
+++ b/vcg/complex/algorithms/create/advancing_front.h
@@ -366,7 +366,8 @@ public:
 protected:
   void AddFace(int v0, int v1, int v2) {
     FaceIterator fi = vcg::tri::Allocator<MESH>::AddFace(mesh,v0,v1,v2);
-    fi->N() = TriangleNormal(*fi).Normalize();
+    if (FaceType::HasNormal())
+      fi->N() = TriangleNormal(*fi).Normalize();
     if(tri::HasVFAdjacency(mesh))
     {
       for(int j=0;j<3;++j)


### PR DESCRIPTION
The AdvancingFront algorithm attempts to update the face normals as it goes, but this fails for face types that don't have normals attached to them. This patch adds a check to ensure that the face type supports normals before calculating and assigning the normal to the face.