### PR TITLE
add CMakeLists.txt for metro

### DIFF
--- a/apps/metro/CMakeLists.txt
+++ b/apps/metro/CMakeLists.txt
@@ -1,0 +1,6 @@
+project(metro CXX)
+cmake_minimum_required(VERSION 3.1)
+set(CMAKE_CXX_STANDARD 11)
+
+include_directories("../../")
+add_executable(metro metro.cpp ../../wrap/ply/plylib.cpp)


### PR DESCRIPTION
People that don't have Qt may need this simple CMakeLists.txt.