### PR TITLE
Remove unused functions failing to compile in GCC

### DIFF
--- a/wrap/io_trimesh/import_nvm.h
+++ b/wrap/io_trimesh/import_nvm.h
@@ -85,15 +85,6 @@ static bool ReadHeader(FILE *fp,unsigned int &num_cams){
     return true;
 }
 
-static bool ReadHeader(const char * filename,unsigned int &/*num_cams*/, unsigned int &/*num_points*/){
-    FILE *fp = fopen(filename, "r");
-    if(!fp) return false;
-    ReadHeader(fp);
-    fclose(fp);
-    return true;
-}
-
-
 static int Open( OpenMeshType &m, std::vector<Shot<ScalarType> >  & shots,
                  std::vector<std::string > & image_filenames,
                  const char * filename, CallBackPos *cb=0)

--- a/wrap/io_trimesh/import_out.h
+++ b/wrap/io_trimesh/import_out.h
@@ -85,15 +85,6 @@ static bool ReadHeader(FILE *fp,unsigned int &num_cams, unsigned int &num_points
     return true;
 }
 
-static bool ReadHeader(const char * filename,unsigned int &/*num_cams*/, unsigned int &/*num_points*/){
-    FILE *fp = fopen(filename, "r");
-    if(!fp) return false;
-    ReadHeader(fp);
-    fclose(fp);
-    return true;
-}
-
-
 static int Open( OpenMeshType &m, std::vector<Shot<ScalarType> >  & shots,
                  std::vector<std::string > & image_filenames,
                  const char * filename,const char * filename_images, CallBackPos *cb=0)


### PR DESCRIPTION
When I tried to build MeshLab with GCC (7.4) I failed to compile VCGLib without modification. After switching to Clang first (as is done in MeshLab's CI configuration) and everything compiled fine I fixed this issue locally and later found that there is already #42 opened.
Although the ticket already contains proposed fixes that are similar to mine I figured I had already fixed that locally and there is no minimal PR available to solve this issue I'll send my changes as PR in the hope that this issue will now be resolved and does not require any GCC user to hunt a compile error that has probably been fixed more often than mentioned in #42 already.