### PR TITLE
Fix missing virtual destructor warnings

### DIFF
--- a/vcg/complex/algorithms/hole.h
+++ b/vcg/complex/algorithms/hole.h
@@ -100,6 +100,8 @@ public:
     ComputeQuality();
     ComputeAngle();
   }
+  // enforce virtual dtor for this class and all subclasses
+  virtual ~TrivialEar() = default;
 
   /// Compute the angle of the two edges of the ear.
   // it tries to make the computation in a precision safe way.

--- a/wrap/openfbx/src/ofbx.cpp
+++ b/wrap/openfbx/src/ofbx.cpp
@@ -355,7 +355,7 @@ struct Property : IElementProperty
 };
 
 
-struct Element : IElement
+struct Element final : IElement
 {
 	IElement* getFirstChild() const override { return child; }
 	IElement* getSibling() const override { return sibling; }


### PR DESCRIPTION
When compiling locally the warnings about missing virtual destructors caught my attention. It took me quite some time to convince myself that the missing destructors are not actual bugs yet. Although by now I'm quite sure these classes are always deleted using the correct type of pointer, I think it is still somewhat brittle to rely on the developer using the correct pointer type.