### PR TITLE
io_trimesh: Fix meshlab build by restoring some arguments.

### DIFF
--- a/wrap/io_trimesh/import_nvm.h
+++ b/wrap/io_trimesh/import_nvm.h
@@ -85,10 +85,10 @@ static bool ReadHeader(FILE *fp,unsigned int &num_cams){
     return true;
 }
 
-static bool ReadHeader(const char * filename,unsigned int &/*num_cams*/, unsigned int &/*num_points*/){
+static bool ReadHeader(const char * filename,unsigned int &num_cams, unsigned int &/*num_points*/){
     FILE *fp = fopen(filename, "r");
     if(!fp) return false;
-    ReadHeader(fp);
+    ReadHeader(fp, num_cams);
     fclose(fp);
     return true;
 }

--- a/wrap/io_trimesh/import_out.h
+++ b/wrap/io_trimesh/import_out.h
@@ -85,10 +85,10 @@ static bool ReadHeader(FILE *fp,unsigned int &num_cams, unsigned int &num_points
     return true;
 }
 
-static bool ReadHeader(const char * filename,unsigned int &/*num_cams*/, unsigned int &/*num_points*/){
+static bool ReadHeader(const char * filename,unsigned int & num_cams , unsigned int & num_points ){
     FILE *fp = fopen(filename, "r");
     if(!fp) return false;
-    ReadHeader(fp);
+    ReadHeader(fp, num_cams, num_points);
     fclose(fp);
     return true;
 }


### PR DESCRIPTION
This is required to fix the build of meshlab master on Debian Buster.