### PR TITLE
Fix some compiler warnings

### DIFF
--- a/vcg/complex/allocate.h
+++ b/vcg/complex/allocate.h
@@ -1330,7 +1330,7 @@ public:
           m.tetra[pos].ImportData(m.tetra[i]);
           //import vertex refs
           for (int j = 0; j < 4; ++j)
-            m.tetra[pos].V(j) = m.tetra[i].cV(j);
+            m.tetra[pos].V(j) = m.tetra[i].V(j);
           //import VT adj
           if (HasVTAdjacency(m))
             for (int j = 0; j < 4; ++j)

--- a/vcg/simplex/tetrahedron/component.h
+++ b/vcg/simplex/tetrahedron/component.h
@@ -45,12 +45,12 @@ All the Components that can be added to a tetra should be defined in the namespa
 template <class T> class EmptyCore : public T {
 public:
     //Empty vertexref
-    inline typename T::VertexType *       & V( const int  ) 	     {	assert(0);		static typename T::VertexType *vp=0; return vp; }
+    inline typename T::VertexType *       & V( const int  ) 	 {	assert(0);		static typename T::VertexType *vp=0; return vp; }
     inline typename T::VertexType * const & V( const int ) const {	assert(0);		static typename T::VertexType *vp=0; return vp; }
-    inline typename T::VertexType * const  cV( const int )    {	assert(0);		static typename T::VertexType *vp=0; return vp;	}
-    inline       typename T::CoordType & P( const int ) 	    {	assert(0);		static typename T::CoordType coord(0, 0, 0); return coord;	}
-    inline const typename T::CoordType & P( const int ) const {	assert(0);		static typename T::CoordType coord(0, 0, 0); return coord;	}
-    inline const typename T::CoordType &cP( const int ) const	{	assert(0);		static typename T::CoordType coord(0, 0, 0); return coord;	}
+    inline const typename T::VertexType *  cV( const int )       {	assert(0);		static typename T::VertexType *vp=0; return vp;	}
+    inline       typename T::CoordType & P( const int ) 	 {	assert(0);		static typename T::CoordType coord(0, 0, 0); return coord;	}
+    inline const typename T::CoordType & P( const int ) const    {	assert(0);		static typename T::CoordType coord(0, 0, 0); return coord;	}
+    inline const typename T::CoordType &cP( const int ) const	 {	assert(0);		static typename T::CoordType coord(0, 0, 0); return coord;	}
 
     static bool HasVertexRef()   { return false; }
     static bool HasTVAdjacency() { return false; }
@@ -177,8 +177,8 @@ public:
     typedef typename T::VertexType::CoordType CoordType;
     typedef typename T::VertexType::ScalarType ScalarType;
 
-    inline typename T::VertexType *       & V( const int j ) 	     { assert(j>=0 && j<4); return v[j]; }
-    inline typename T::VertexType * const  cV( const int j )  { assert(j>=0 && j<4);	return v[j]; }
+    inline       typename T::VertexType * & V( const int j ) { assert(j>=0 && j<4); return v[j]; }
+    inline const typename T::VertexType *  cV( const int j ) { assert(j>=0 && j<4); return v[j]; }
 
     inline  size_t cFtoVi (const int f, const int j) const { assert(f >= 0 && f < 4); assert(j >= 0 && j < 3); return findices[f][j]; }
 

--- a/wrap/io_trimesh/import_out.h
+++ b/wrap/io_trimesh/import_out.h
@@ -81,7 +81,7 @@ static bool ReadHeader(FILE *fp,unsigned int &num_cams, unsigned int &num_points
     if(0!=strcmp("# Bundle file v0.3", line))  return false;
     readline(fp, line);
     if(line[0]=='\0') return false;
-    sscanf(line, "%d %d", &num_cams, &num_points);
+    if (sscanf(line, "%d %d", &num_cams, &num_points) != 2) return false;
     return true;
 }
 
@@ -108,13 +108,12 @@ static int Open( OpenMeshType &m, std::vector<Shot<ScalarType> >  & shots,
     float R[16]={0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,1};
     vcg::Point3f t;
 
-    readline(fp, line); if(line[0]=='\0') return false; sscanf(line, "%f %f %f", &f, &k1, &k2);
+    readline(fp, line); if(line[0]=='\0') return false; if (sscanf(line, "%f %f %f", &f, &k1, &k2) != 3) return false;
 
-    readline(fp, line); if(line[0]=='\0') return false; sscanf(line, "%f %f %f", &(R[0]), &(R[1]), &(R[2]));  R[3] = 0;
-    readline(fp, line); if(line[0]=='\0') return false; sscanf(line, "%f %f %f", &(R[4]), &(R[5]), &(R[6]));  R[7] = 0;
-    readline(fp, line); if(line[0]=='\0') return false; sscanf(line, "%f %f %f", &(R[8]), &(R[9]), &(R[10])); R[11] = 0;
-
-    readline(fp, line); if(line[0]=='\0') return false; sscanf(line, "%f %f %f", &(t[0]), &(t[1]), &(t[2]));
+    readline(fp, line); if(line[0]=='\0') return false; if (sscanf(line, "%f %f %f", &(R[0]), &(R[1]), &(R[2])) != 3) return false; R[3] = 0;
+    readline(fp, line); if(line[0]=='\0') return false; if (sscanf(line, "%f %f %f", &(R[4]), &(R[5]), &(R[6])) != 3) return false; R[7] = 0;
+    readline(fp, line); if(line[0]=='\0') return false; if (sscanf(line, "%f %f %f", &(R[8]), &(R[9]), &(R[10])) != 3) return false; R[11] = 0;
+    readline(fp, line); if(line[0]=='\0') return false; if (sscanf(line, "%f %f %f", &(t[0]), &(t[1]), &(t[2])) != 3) return false;;
 
     Matrix44x mat = Matrix44x::Construct(Matrix44f(R));
 
@@ -152,14 +151,14 @@ static int Open( OpenMeshType &m, std::vector<Shot<ScalarType> >  & shots,
   for(uint i = 0; i < num_points;++i,++vi){
     double x,y,z;
     unsigned int r,g,b,i_cam, key_sift,n_corr;
-    fscanf(fp,"%lf %lf %lf ",&x,&y,&z);
+    if (fscanf(fp,"%lf %lf %lf ",&x,&y,&z) != 3) return false;
     (*vi).P() = vcg::Point3<typename OpenMeshType::ScalarType>(x,y,z);
-    fscanf(fp,"%d %d %d ",&r,&g,&b);
+    if (fscanf(fp,"%d %d %d ",&r,&g,&b) != 3) return false;
     (*vi).C() = vcg::Color4b(r,g,b,255);
 
-    fscanf(fp,"%d ",&n_corr);
+    if (fscanf(fp,"%d ",&n_corr) != 1) return false;
     for(uint j = 0; j < n_corr; ++j){
-      fscanf(fp,"%d %d %lf %lf ",&i_cam,&key_sift,&x,&y);
+      if (fscanf(fp,"%d %d %lf %lf ",&i_cam,&key_sift,&x,&y) != 4) return false;
       Correspondence corr(i_cam,key_sift,x,y);
       ch[i].push_back(corr);
     }
@@ -181,7 +180,7 @@ static bool ReadImagesFilenames(const char *  filename,std::vector<std::string> 
         while(!feof(fp)){
             readline(fp, line, 1000);
             if(line[0] == '\0') continue; //ignore empty lines (in theory, might happen only at end of file)
-            sscanf(line, "%s", name);
+            if (sscanf(line, "%s", name) != 1) return false;
             std::string n(name);
             image_filenames.push_back(n);
         }


### PR DESCRIPTION
I fixed some compilers warnings when compiling meshlab. These also improve the robustness, as the checks I add will guarantee that the desired number of variables to be read is actually read. 