### PR TITLE
Remove GLEW include from library header.

### DIFF
--- a/wrap/gl/camera.h
+++ b/wrap/gl/camera.h
@@ -79,9 +79,6 @@ creation
 // VCG
 #include <vcg/math/camera.h>
 
-// opengl
-#include <GL/glew.h>
-
 template <class CameraType>
 struct GlCamera{
 


### PR DESCRIPTION
All other library headers in vcglib used in Meshlab
state you must already have your extension loader included.
(This lets you use non-GLEW loaders.) This fixes the lone
outlier.