### PR TITLE
Bugfix: Per the obj specification indices must start from 1

### DIFF
--- a/wrap/io_trimesh/import_obj.h
+++ b/wrap/io_trimesh/import_obj.h
@@ -183,6 +183,7 @@ public:
   static bool GoodObjIndex(int &index, const int maxVal)
   {
     if (index > maxVal)	return false;
+    if (index == 0) return false; // indices must start from 1
     if (index < 0)
     {
       index += maxVal+1;


### PR DESCRIPTION
I managed to make Meshlab crash. The problem was due to the fact that the reader for the .obj files did not check that vertex indices start from 1. (See https://en.wikipedia.org/wiki/Wavefront_.obj_file#Vertex_indices)

To reproduce the crash, take an .obj file, look at a face, such as:

f 1/1 2/2 3/3

and replace that with:

f 0/0 1/1 2/2

The code in that reader looks as if the author knew about this, as in another place an adjustment was made for this, but only in a very special case.

This fix will prevent the crash. But it is not enough. If the user has indices starting with 0, Meshlab should refuse to load the file altogether, as corrupt, rather than skipping some triangles while letting others in. 