### PR TITLE
Update Dot.h

### DIFF
--- a/eigenlib/Eigen/src/Core/Dot.h
+++ b/eigenlib/Eigen/src/Core/Dot.h
@@ -19,12 +19,7 @@ namespace internal {
 // looking at the static assertions. Thus this is a trick to get better compile errors.
 template<typename T, typename U,
 // the NeedToTranspose condition here is taken straight from Assign.h
-         bool NeedToTranspose = T::IsVectorAtCompileTime
-                && U::IsVectorAtCompileTime
-                && ((int(T::RowsAtCompileTime) == 1 && int(U::ColsAtCompileTime) == 1)
-                      |  // FIXME | instead of || to please GCC 4.4.0 stupid warning "suggest parentheses around &&".
-                         // revert to || as soon as not needed anymore.
-                    (int(T::ColsAtCompileTime) == 1 && int(U::RowsAtCompileTime) == 1))
+         bool NeedToTranspose = (T::IsVectorAtCompileTime)&&(U::IsVectorAtCompileTime)&&((int(T::RowsAtCompileTime)==1)&&(int(U::ColsAtCompileTime)==1))||((int(T::ColsAtCompileTime)==1)&&(int(U::RowsAtCompileTime) == 1))
 >
 struct dot_nocheck
 {
@@ -76,7 +71,7 @@ MatrixBase<Derived>::dot(const MatrixBase<OtherDerived>& other) const
   EIGEN_CHECK_BINARY_COMPATIBILIY(func,Scalar,typename OtherDerived::Scalar);
 #endif
   
-  eigen_assert(size() == other.size());
+  eigen_assert(size()==other.size());
 
   return internal::dot_nocheck<Derived,OtherDerived>::run(*this, other);
 }
@@ -84,7 +79,7 @@ MatrixBase<Derived>::dot(const MatrixBase<OtherDerived>& other) const
 //---------- implementation of L2 norm and related functions ----------
 
 /** \returns, for vectors, the squared \em l2 norm of \c *this, and for matrices the Frobenius norm.
-  * In both cases, it consists in the sum of the square of all the matrix entries.
+  * In both cases, it consists of the sum of the square of all the matrix entries.
   * For vectors, this is also equals to the dot product of \c *this with itself.
   *
   * \sa dot(), norm(), lpNorm()
@@ -173,7 +168,7 @@ MatrixBase<Derived>::stableNormalized() const
     return n;
 }
 
-/** Normalizes the vector while avoid underflow and overflow
+/** Normalizes the vector while avoiding underflow and overflow
   *
   * \only_for_vectors
   *


### PR DESCRIPTION
maybe correction to the next:
&& U::IsVectorAtCompileTime
                && ((int(T::RowsAtCompileTime) == 1 && int(U::ColsAtCompileTime) == 1)
                      |  // FIXME | instead of || to please GCC 4.4.0 stupid warning "suggest parentheses around &&".
                         // revert to || as soon as not needed anymore.
                    (int(T::ColsAtCompileTime) == 1 && int(U::RowsAtCompileTime) == 1))

## Thank you for sending a Pull Request to the VCGLib! 

VCGLib is fully owned by CNR, and all the VCGLib contributors that do not work at the VCLab of CNR must first sign the contributor license agreement that you can find at the following link: https://github.com/cnr-isti-vclab/vcglib/blob/devel/docs/ContributorLicenseAgreement.pdf

If you will sign the CLA, then we will be able to merge your pull request after reviewing it.
Please send the signed document to muntoni.alessandro@gmail.com and paolo.cignoni@isti.cnr.it .
If you will not sign the CLA, we will review and then apply your changes as soon as possible.

Before opening the PR, please leave the follwing form with a check for your particluar case:

##### Check with `[x]` what is your case:
- [ ] I already signed and sent via email the CLA;
- [ ] I wil sign and send the CLA via email as soon as possible;
- [ ] I don't want to sign the CLA.