### PR TITLE
fix typos

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## Thank you for sending a Pull Request to the VCGLib! 
+## Thank you for sending a Pull Request to the VCGLib!
 
 VCGLib is fully owned by CNR, and all the VCGLib contributors that do not work at the VCLab of CNR must first sign the contributor license agreement that you can find at the following link: https://github.com/cnr-isti-vclab/vcglib/blob/devel/docs/ContributorLicenseAgreement.pdf
 
@@ -6,9 +6,9 @@ If you will sign the CLA, then we will be able to merge your pull request after 
 Please send the signed document to muntoni.alessandro@gmail.com and paolo.cignoni@isti.cnr.it .
 If you will not sign the CLA, we will review and then apply your changes as soon as possible.
 
-Before opening the PR, please leave the follwing form with a check for your particluar case:
+Before opening the PR, please leave the following form with a check for your particular case:
 
 ##### Check with `[x]` what is your case:
 - [ ] I already signed and sent via email the CLA;
-- [ ] I wil sign and send the CLA via email as soon as possible;
+- [ ] I will sign and send the CLA via email as soon as possible;
 - [ ] I don't want to sign the CLA.

--- a/wrap/io_trimesh/export_ply.h
+++ b/wrap/io_trimesh/export_ply.h
@@ -923,7 +923,7 @@ public:
 
 			ply_error_msg[PlyInfo::E_NO_VERTEX	  ]="No vertex field found";
 			ply_error_msg[PlyInfo::E_NO_FACE		]="No face field found";
-			ply_error_msg[PlyInfo::E_SHORTFILE	  ]="Unespected eof";
+			ply_error_msg[PlyInfo::E_SHORTFILE	  ]="Unexpected EOF";
 			ply_error_msg[PlyInfo::E_NO_3VERTINFACE ]="Face with more than 3 vertices";
 			ply_error_msg[PlyInfo::E_BAD_VERT_INDEX ]="Bad vertex index in face";
 			ply_error_msg[PlyInfo::E_NO_6TCOORD	 ]="Face with no 6 texture coordinates";

--- a/wrap/io_trimesh/import_ply.h
+++ b/wrap/io_trimesh/import_ply.h
@@ -328,7 +328,7 @@ public:
 
 			ply_error_msg[PlyInfo::E_NO_VERTEX      ]="No vertex field found";
 			ply_error_msg[PlyInfo::E_NO_FACE        ]="No face field found";
-			ply_error_msg[PlyInfo::E_SHORTFILE      ]="Unespected eof";
+			ply_error_msg[PlyInfo::E_SHORTFILE      ]="Unexpected EOF";
 			ply_error_msg[PlyInfo::E_NO_3VERTINFACE ]="Face with more than 3 vertices";
 			ply_error_msg[PlyInfo::E_BAD_VERT_INDEX ]="Bad vertex index in face";
 			ply_error_msg[PlyInfo::E_BAD_VERT_INDEX_EDGE ]="Bad vertex index in edge";


### PR DESCRIPTION
This fixes some typos.

##### Check with `[x]` what is your case:
- [x] I already signed and sent via email the CLA;
- [ ] I will sign and send the CLA via email as soon as possible;
- [ ] I don't want to sign the CLA.