### PR TITLE
Added a `precision` parameter to ExporterOBJ::Save() to specify the d…

### DIFF
--- a/wrap/io_trimesh/export_obj.h
+++ b/wrap/io_trimesh/export_obj.h
@@ -114,9 +114,9 @@ public:
     return capability;
   }
   
-  static int Save(SaveMeshType &m, const char * filename, int mask, CallBackPos *cb=0)
+  static int Save(SaveMeshType &m, const char * filename, int mask, CallBackPos *cb=0, int precision = 0)
   {
-    return Save(m,filename,mask,false,cb);
+	return Save(m,filename,mask,false,cb, precision);
   }
   
   /** 
@@ -124,8 +124,15 @@ public:
    * 
    * if you enable the useMaterialAttribute flag, the exporter will assume that the mesh has a consistent per mesh attribute and a per face attribute containing the index of the material
    */
-  static int Save(SaveMeshType &m, const char * filename, int mask, bool useMaterialAttribute ,CallBackPos *cb=0)
+  static int Save(SaveMeshType &m, const char * filename, int mask, bool useMaterialAttribute ,CallBackPos *cb=0, int precision = 6)
   {
+	if (precision < 1) precision = 1;
+	if (precision > 16) precision = 16;
+	std::string floatfmt = "%." + std::to_string(precision) + "f";
+	std::string vfmt = "v " + floatfmt + " " + floatfmt + " " + floatfmt;
+	std::string vnfmt = "vn " + floatfmt + " " + floatfmt + " " + floatfmt + "\n";
+	std::string vtfmt = "vt " + floatfmt + " " + floatfmt + "\n";
+
     // texture coord and color: in obj we cannot save BOTH per vertex and per wedge information. We default on wedge
     if (mask & vcg::tri::io::Mask::IOM_WEDGTEXCOORD &&
         mask & vcg::tri::io::Mask::IOM_VERTTEXCOORD ) {
@@ -176,19 +183,19 @@ public:
       {
         if(AddNewNormalVertex(NormalVertex,(*vi).N(),curNormalIndex))
         {
-          fprintf(fp,"vn %f %f %f\n",(*vi).N()[0],(*vi).N()[1],(*vi).N()[2]);
+		  fprintf(fp,vnfmt.c_str(),(*vi).N()[0],(*vi).N()[1],(*vi).N()[2]);
           curNormalIndex++;
         }
       }
       if (mask & Mask::IOM_VERTNORMAL ) {
-        fprintf(fp,"vn %f %f %f\n",(*vi).N()[0],(*vi).N()[1],(*vi).N()[2]);
+		fprintf(fp,vnfmt.c_str(),(*vi).N()[0],(*vi).N()[1],(*vi).N()[2]);
       }
       
       if (mask & Mask::IOM_VERTTEXCOORD ) {
-        fprintf(fp,"vt %f %f\n",(*vi).T().P()[0],(*vi).T().P()[1]);
+		fprintf(fp,vtfmt.c_str(),(*vi).T().P()[0],(*vi).T().P()[1]);
       }
 
-      fprintf(fp,"v %f %f %f",(*vi).P()[0],(*vi).P()[1],(*vi).P()[2]);
+	  fprintf(fp,vfmt.c_str(),(*vi).P()[0],(*vi).P()[1],(*vi).P()[2]);
       
       if(mask & Mask::IOM_VERTCOLOR) // the socially accepted extension to the obj format. 
         fprintf(fp," %f %f %f",double((*vi).C()[0])/255.,double((*vi).C()[1])/255.,double((*vi).C()[2])/255.);
@@ -234,7 +241,7 @@ public:
         {
             if(AddNewTextureCoord(CoordIndexTexture,(*fi).WT(k),curTexCoordIndex))
             {
-              fprintf(fp,"vt %f %f\n",(*fi).WT(k).u(),(*fi).WT(k).v());
+			  fprintf(fp,vtfmt.c_str(),(*fi).WT(k).u(),(*fi).WT(k).v());
               curTexCoordIndex++; //ncreases the value number to be associated to the Texture
             }
         }

--- a/wrap/io_trimesh/export_obj.h
+++ b/wrap/io_trimesh/export_obj.h
@@ -29,6 +29,7 @@
 #include <wrap/callback.h>
 #include <wrap/io_trimesh/io_mask.h>
 #include <wrap/io_trimesh/io_material.h>
+#include <wrap/io_trimesh/precision.h>
 #include <iostream>
 #include <fstream>
 #include <map>
@@ -65,7 +66,7 @@ public:
     E_NO_VERTICES,        // 6
     E_NOTFACESVALID,      // 7
     E_NO_VALID_MATERIAL,  // 8
-	E_STREAMERROR         // 9
+    E_STREAMERROR         // 9
   };
 
   /*
@@ -84,7 +85,7 @@ public:
       "Vertices not valid",  // 6
       "Faces not valid",  // 7
       "The mesh has not a attribute containing the vector of materials",  // 8
-	  "Output Stream Error" //9
+      "Output Stream Error" //9
     };
 
     if(error>9 || error<0) return "Unknown error";
@@ -126,8 +127,8 @@ public:
    */
   static int Save(SaveMeshType &m, const char * filename, int mask, bool useMaterialAttribute ,CallBackPos *cb=0)
   {
-	const int DGT = vcg::tri::io::Precision<ScalarType>::digits();
-	// texture coord and color: in obj we cannot save BOTH per vertex and per wedge information. We default on wedge
+    const int DGT = vcg::tri::io::Precision<ScalarType>::digits();
+    // texture coord and color: in obj we cannot save BOTH per vertex and per wedge information. We default on wedge
     if (mask & vcg::tri::io::Mask::IOM_WEDGTEXCOORD &&
         mask & vcg::tri::io::Mask::IOM_VERTTEXCOORD ) {
       mask &= ~vcg::tri::io::Mask::IOM_VERTTEXCOORD;
@@ -177,22 +178,22 @@ public:
       {
         if(AddNewNormalVertex(NormalVertex,(*vi).N(),curNormalIndex))
         {
-		  fprintf(fp,"vn %.*f %.*f %.*f\n", DGT, (*vi).N()[0], DGT, (*vi).N()[1], DGT, (*vi).N()[2]);
+          fprintf(fp,"vn %.*f %.*f %.*f\n", DGT, (*vi).N()[0], DGT, (*vi).N()[1], DGT, (*vi).N()[2]);
           curNormalIndex++;
         }
       }
       if (mask & Mask::IOM_VERTNORMAL ) {
-		fprintf(fp,"vn %.*f %.*f %.*f\n", DGT, (*vi).N()[0], DGT, (*vi).N()[1], DGT, (*vi).N()[2]);
+        fprintf(fp,"vn %.*f %.*f %.*f\n", DGT, (*vi).N()[0], DGT, (*vi).N()[1], DGT, (*vi).N()[2]);
       }
       
       if (mask & Mask::IOM_VERTTEXCOORD ) {
-		fprintf(fp,"vt %.*f %.*f\n", DGT, (*vi).T().P()[0], DGT, (*vi).T().P()[1]);
+        fprintf(fp,"vt %.*f %.*f\n", DGT, (*vi).T().P()[0], DGT, (*vi).T().P()[1]);
       }
 
-	  fprintf(fp,"v %.*f %.*f %.*f", DGT, (*vi).P()[0], DGT, (*vi).P()[1], DGT, (*vi).P()[2]);
+      fprintf(fp,"v %.*f %.*f %.*f", DGT, (*vi).P()[0], DGT, (*vi).P()[1], DGT, (*vi).P()[2]);
       
       if(mask & Mask::IOM_VERTCOLOR) // the socially accepted extension to the obj format. 
-		fprintf(fp," %f %f %f",DGT, double((*vi).C()[0])/255.,double((*vi).C()[1])/255.,double((*vi).C()[2])/255.);
+        fprintf(fp," %f %f %f", double((*vi).C()[0])/255., double((*vi).C()[1])/255., double((*vi).C()[2])/255.);
       fprintf(fp,"\n");
 
       if (cb !=NULL)
@@ -235,7 +236,7 @@ public:
         {
             if(AddNewTextureCoord(CoordIndexTexture,(*fi).WT(k),curTexCoordIndex))
             {
-			  fprintf(fp,"vt %.*f %.*f\n", DGT, (*fi).WT(k).u(), DGT, (*fi).WT(k).v());
+              fprintf(fp,"vt %.*f %.*f\n", DGT, (*fi).WT(k).u(), DGT, (*fi).WT(k).v());
               curTexCoordIndex++; //ncreases the value number to be associated to the Texture
             }
         }
@@ -290,13 +291,13 @@ public:
       else                     errCode = WriteMaterials(materialVec, filename,cb);
     }
 
-	int result = E_NOERROR;
-	if (errCode != E_NOERROR)
-		result = errCode;
-	else if (ferror(fp))
-		result = E_STREAMERROR;
-	fclose(fp);
-	return result;
+    int result = E_NOERROR;
+    if (errCode != E_NOERROR)
+        result = errCode;
+    else if (ferror(fp))
+        result = E_STREAMERROR;
+    fclose(fp);
+    return result;
   }
 
    /*
@@ -394,12 +395,12 @@ public:
         { /* fclose(fp); return E_ABORTED; */ }
 
         fprintf(fp,"newmtl material_%d\n",i);
-		fprintf(fp,"Ka %f %f %f\n",materialVec[i].Ka[0],materialVec[i].Ka[1],materialVec[i].Ka[2]);
-		fprintf(fp,"Kd %f %f %f\n",materialVec[i].Kd[0],materialVec[i].Kd[1],materialVec[i].Kd[2]);
-		fprintf(fp,"Ks %f %f %f\n",materialVec[i].Ks[0],materialVec[i].Ks[1],materialVec[i].Ks[2]);
-		fprintf(fp,"Tr %f\n",materialVec[i].Tr);
+        fprintf(fp,"Ka %f %f %f\n",materialVec[i].Ka[0],materialVec[i].Ka[1],materialVec[i].Ka[2]);
+        fprintf(fp,"Kd %f %f %f\n",materialVec[i].Kd[0],materialVec[i].Kd[1],materialVec[i].Kd[2]);
+        fprintf(fp,"Ks %f %f %f\n",materialVec[i].Ks[0],materialVec[i].Ks[1],materialVec[i].Ks[2]);
+        fprintf(fp,"Tr %f\n",materialVec[i].Tr);
         fprintf(fp,"illum %d\n",materialVec[i].illum);
-		fprintf(fp,"Ns %f\n",materialVec[i].Ns);
+        fprintf(fp,"Ns %f\n",materialVec[i].Ns);
 
         if(materialVec[i].map_Kd.size()>0)
           fprintf(fp,"map_Kd %s\n",materialVec[i].map_Kd.c_str());

--- a/wrap/io_trimesh/export_obj.h
+++ b/wrap/io_trimesh/export_obj.h
@@ -116,7 +116,7 @@ public:
   
   static int Save(SaveMeshType &m, const char * filename, int mask, CallBackPos *cb=0, int precision = 0)
   {
-	return Save(m,filename,mask,false,cb, precision);
+    return Save(m,filename,mask,false,cb, precision);
   }
   
   /** 
@@ -126,12 +126,12 @@ public:
    */
   static int Save(SaveMeshType &m, const char * filename, int mask, bool useMaterialAttribute ,CallBackPos *cb=0, int precision = 6)
   {
-	if (precision < 1) precision = 1;
-	if (precision > 16) precision = 16;
-	std::string floatfmt = "%." + std::to_string(precision) + "f";
-	std::string vfmt = "v " + floatfmt + " " + floatfmt + " " + floatfmt;
-	std::string vnfmt = "vn " + floatfmt + " " + floatfmt + " " + floatfmt + "\n";
-	std::string vtfmt = "vt " + floatfmt + " " + floatfmt + "\n";
+    if (precision < 1) precision = 1;
+    if (precision > 16) precision = 16;
+    std::string floatfmt = "%." + std::to_string(precision) + "f";
+    std::string vfmt = "v " + floatfmt + " " + floatfmt + " " + floatfmt;
+    std::string vnfmt = "vn " + floatfmt + " " + floatfmt + " " + floatfmt + "\n";
+    std::string vtfmt = "vt " + floatfmt + " " + floatfmt + "\n";
 
     // texture coord and color: in obj we cannot save BOTH per vertex and per wedge information. We default on wedge
     if (mask & vcg::tri::io::Mask::IOM_WEDGTEXCOORD &&
@@ -183,19 +183,19 @@ public:
       {
         if(AddNewNormalVertex(NormalVertex,(*vi).N(),curNormalIndex))
         {
-		  fprintf(fp,vnfmt.c_str(),(*vi).N()[0],(*vi).N()[1],(*vi).N()[2]);
+          fprintf(fp,vnfmt.c_str(),(*vi).N()[0],(*vi).N()[1],(*vi).N()[2]);
           curNormalIndex++;
         }
       }
       if (mask & Mask::IOM_VERTNORMAL ) {
-		fprintf(fp,vnfmt.c_str(),(*vi).N()[0],(*vi).N()[1],(*vi).N()[2]);
+        fprintf(fp,vnfmt.c_str(),(*vi).N()[0],(*vi).N()[1],(*vi).N()[2]);
       }
       
       if (mask & Mask::IOM_VERTTEXCOORD ) {
-		fprintf(fp,vtfmt.c_str(),(*vi).T().P()[0],(*vi).T().P()[1]);
+        fprintf(fp,vtfmt.c_str(),(*vi).T().P()[0],(*vi).T().P()[1]);
       }
 
-	  fprintf(fp,vfmt.c_str(),(*vi).P()[0],(*vi).P()[1],(*vi).P()[2]);
+      fprintf(fp,vfmt.c_str(),(*vi).P()[0],(*vi).P()[1],(*vi).P()[2]);
       
       if(mask & Mask::IOM_VERTCOLOR) // the socially accepted extension to the obj format. 
         fprintf(fp," %f %f %f",double((*vi).C()[0])/255.,double((*vi).C()[1])/255.,double((*vi).C()[2])/255.);
@@ -241,7 +241,7 @@ public:
         {
             if(AddNewTextureCoord(CoordIndexTexture,(*fi).WT(k),curTexCoordIndex))
             {
-			  fprintf(fp,vtfmt.c_str(),(*fi).WT(k).u(),(*fi).WT(k).v());
+              fprintf(fp,vtfmt.c_str(),(*fi).WT(k).u(),(*fi).WT(k).v());
               curTexCoordIndex++; //ncreases the value number to be associated to the Texture
             }
         }

--- a/wrap/io_trimesh/export_obj.h
+++ b/wrap/io_trimesh/export_obj.h
@@ -114,9 +114,9 @@ public:
     return capability;
   }
   
-  static int Save(SaveMeshType &m, const char * filename, int mask, CallBackPos *cb=0, int precision = 0)
+  static int Save(SaveMeshType &m, const char * filename, int mask, CallBackPos *cb=0)
   {
-    return Save(m,filename,mask,false,cb, precision);
+    return Save(m,filename,mask,false,cb);
   }
   
   /** 
@@ -124,16 +124,10 @@ public:
    * 
    * if you enable the useMaterialAttribute flag, the exporter will assume that the mesh has a consistent per mesh attribute and a per face attribute containing the index of the material
    */
-  static int Save(SaveMeshType &m, const char * filename, int mask, bool useMaterialAttribute ,CallBackPos *cb=0, int precision = 6)
+  static int Save(SaveMeshType &m, const char * filename, int mask, bool useMaterialAttribute ,CallBackPos *cb=0)
   {
-    if (precision < 1) precision = 1;
-    if (precision > 16) precision = 16;
-    std::string floatfmt = "%." + std::to_string(precision) + "f";
-    std::string vfmt = "v " + floatfmt + " " + floatfmt + " " + floatfmt;
-    std::string vnfmt = "vn " + floatfmt + " " + floatfmt + " " + floatfmt + "\n";
-    std::string vtfmt = "vt " + floatfmt + " " + floatfmt + "\n";
-
-    // texture coord and color: in obj we cannot save BOTH per vertex and per wedge information. We default on wedge
+	const int DGT = vcg::tri::io::Precision<ScalarType>::digits();
+	// texture coord and color: in obj we cannot save BOTH per vertex and per wedge information. We default on wedge
     if (mask & vcg::tri::io::Mask::IOM_WEDGTEXCOORD &&
         mask & vcg::tri::io::Mask::IOM_VERTTEXCOORD ) {
       mask &= ~vcg::tri::io::Mask::IOM_VERTTEXCOORD;
@@ -183,22 +177,22 @@ public:
       {
         if(AddNewNormalVertex(NormalVertex,(*vi).N(),curNormalIndex))
         {
-          fprintf(fp,vnfmt.c_str(),(*vi).N()[0],(*vi).N()[1],(*vi).N()[2]);
+		  fprintf(fp,"vn %.*f %.*f %.*f\n", DGT, (*vi).N()[0], DGT, (*vi).N()[1], DGT, (*vi).N()[2]);
           curNormalIndex++;
         }
       }
       if (mask & Mask::IOM_VERTNORMAL ) {
-        fprintf(fp,vnfmt.c_str(),(*vi).N()[0],(*vi).N()[1],(*vi).N()[2]);
+		fprintf(fp,"vn %.*f %.*f %.*f\n", DGT, (*vi).N()[0], DGT, (*vi).N()[1], DGT, (*vi).N()[2]);
       }
       
       if (mask & Mask::IOM_VERTTEXCOORD ) {
-        fprintf(fp,vtfmt.c_str(),(*vi).T().P()[0],(*vi).T().P()[1]);
+		fprintf(fp,"vt %.*f %.*f\n", DGT, (*vi).T().P()[0], DGT, (*vi).T().P()[1]);
       }
 
-      fprintf(fp,vfmt.c_str(),(*vi).P()[0],(*vi).P()[1],(*vi).P()[2]);
+	  fprintf(fp,"v %.*f %.*f %.*f", DGT, (*vi).P()[0], DGT, (*vi).P()[1], DGT, (*vi).P()[2]);
       
       if(mask & Mask::IOM_VERTCOLOR) // the socially accepted extension to the obj format. 
-        fprintf(fp," %f %f %f",double((*vi).C()[0])/255.,double((*vi).C()[1])/255.,double((*vi).C()[2])/255.);
+		fprintf(fp," %f %f %f",DGT, double((*vi).C()[0])/255.,double((*vi).C()[1])/255.,double((*vi).C()[2])/255.);
       fprintf(fp,"\n");
 
       if (cb !=NULL)
@@ -241,7 +235,7 @@ public:
         {
             if(AddNewTextureCoord(CoordIndexTexture,(*fi).WT(k),curTexCoordIndex))
             {
-              fprintf(fp,vtfmt.c_str(),(*fi).WT(k).u(),(*fi).WT(k).v());
+			  fprintf(fp,"vt %.*f %.*f\n", DGT, (*fi).WT(k).u(), DGT, (*fi).WT(k).v());
               curTexCoordIndex++; //ncreases the value number to be associated to the Texture
             }
         }
@@ -400,12 +394,12 @@ public:
         { /* fclose(fp); return E_ABORTED; */ }
 
         fprintf(fp,"newmtl material_%d\n",i);
-        fprintf(fp,"Ka %f %f %f\n",materialVec[i].Ka[0],materialVec[i].Ka[1],materialVec[i].Ka[2]);
-        fprintf(fp,"Kd %f %f %f\n",materialVec[i].Kd[0],materialVec[i].Kd[1],materialVec[i].Kd[2]);
-        fprintf(fp,"Ks %f %f %f\n",materialVec[i].Ks[0],materialVec[i].Ks[1],materialVec[i].Ks[2]);
-        fprintf(fp,"Tr %f\n",materialVec[i].Tr);
+		fprintf(fp,"Ka %f %f %f\n",materialVec[i].Ka[0],materialVec[i].Ka[1],materialVec[i].Ka[2]);
+		fprintf(fp,"Kd %f %f %f\n",materialVec[i].Kd[0],materialVec[i].Kd[1],materialVec[i].Kd[2]);
+		fprintf(fp,"Ks %f %f %f\n",materialVec[i].Ks[0],materialVec[i].Ks[1],materialVec[i].Ks[2]);
+		fprintf(fp,"Tr %f\n",materialVec[i].Tr);
         fprintf(fp,"illum %d\n",materialVec[i].illum);
-        fprintf(fp,"Ns %f\n",materialVec[i].Ns);
+		fprintf(fp,"Ns %f\n",materialVec[i].Ns);
 
         if(materialVec[i].map_Kd.size()>0)
           fprintf(fp,"map_Kd %s\n",materialVec[i].map_Kd.c_str());

--- a/wrap/io_trimesh/precision.h
+++ b/wrap/io_trimesh/precision.h
@@ -24,17 +24,17 @@ namespace vcg
 
 			// Precision<float> specializations
 			template<>
-			static int Precision<float>::digits() { return decimalPrecision <= 0 ? 7 : decimalPrecision; }
+			int Precision<float>::digits() { return decimalPrecision <= 0 ? 7 : decimalPrecision; }
 
 			template<>
-			static const char* Precision<float>::typeName() { return "float"; }
+			const char* Precision<float>::typeName() { return "float"; }
 
 			// Precision<double> specializations
 			template<>
-			static int Precision<double>::digits() { return decimalPrecision <= 0 ? 16 : decimalPrecision; }
+			int Precision<double>::digits() { return decimalPrecision <= 0 ? 16 : decimalPrecision; }
 
 			template<>
-			static const char* Precision<double>::typeName() { return "double"; }
+			const char* Precision<double>::typeName() { return "double"; }
 
 		}
 	}

--- a/wrap/io_trimesh/precision.h
+++ b/wrap/io_trimesh/precision.h
@@ -8,26 +8,34 @@ namespace vcg
 		namespace io
 		{
 			template<typename SCALAR>
-			struct Precision
+			class Precision
 			{
+				static int decimalPrecision; // the desired decimal precision
+			public:
 				static int digits() {return 0;}
-                static const char* typeName() {return "";}
+				static void setDigits(int digits) { decimalPrecision = digits; }
+				static const char* typeName() {return "";}
 			};
-			
-			template<>
-			struct Precision<float>
-			{
-				static int digits() {return 7;}
-                static const char* typeName() {return "float";}
 
-			};
-			
+			template <typename SCALAR>
+			int Precision<SCALAR>::decimalPrecision = 0;
+
+			// Precision specializations with reasonable defaults
+
+			// Precision<float> specializations
 			template<>
-			struct Precision<double>
-			{
-				static int digits() {return 16;}
-                static const char* typeName() {return "double";}
-			};
+			static int Precision<float>::digits() { return decimalPrecision <= 0 ? 7 : decimalPrecision; }
+
+			template<>
+			static const char* Precision<float>::typeName() { return "float"; }
+
+			// Precision<double> specializations
+			template<>
+			static int Precision<double>::digits() { return decimalPrecision <= 0 ? 16 : decimalPrecision; }
+
+			template<>
+			static const char* Precision<double>::typeName() { return "double"; }
+
 		}
 	}
 }


### PR DESCRIPTION
…esired number of decimal digits when writing vertex attributes

This change allows users to specify the desired decimal precision when writing OBJ files. In many cases, the default precision of `fprintf` (6 digits) causes data loss (e.g. when converting from binary data formats).

Introducing formatted strings to keep changes to a minimum, although it would probably be better to switch to C++ streams.