### PR TITLE
Force coherence in intersection plane-triangle

### DIFF
--- a/vcg/space/intersection3.h
+++ b/vcg/space/intersection3.h
@@ -283,8 +283,11 @@ namespace vcg {
       typedef typename TRIANGLETYPE::ScalarType T;
       if(IntersectionPlaneSegment(pl,Segment3<T>(tr.cP(0),tr.cP(1)),sg.P0()))
       {
-        if(IntersectionPlaneSegment(pl,Segment3<T>(tr.cP(0),tr.cP(2)),sg.P1()))
+        if(IntersectionPlaneSegment(pl,Segment3<T>(tr.cP(2),tr.cP(0)),sg.P1()))
+        {
+          std::swap(sg.P0(),sg.P1());
           return true;
+        }          
         else
         {
           if(IntersectionPlaneSegment(pl,Segment3<T>(tr.cP(1),tr.cP(2)),sg.P1()))
@@ -297,7 +300,8 @@ namespace vcg {
       {
         if(IntersectionPlaneSegment(pl,Segment3<T>(tr.cP(1),tr.cP(2)),sg.P0()))
         {
-          if(IntersectionPlaneSegment(pl,Segment3<T>(tr.cP(0),tr.cP(2)),sg.P1()))return true;
+          if(IntersectionPlaneSegment(pl,Segment3<T>(tr.cP(2),tr.cP(0)),sg.P1()))
+            return true;
           assert(0);
           return true;
         }


### PR DESCRIPTION
## Thank you for sending a Pull Request to the VCGLib!

### Check the PR branch!

On this repository, we keep two relevant branches:

- `main`: we keep here the **last release version of VCGLib**, with just bugfixes. In case of serious bugs caught after a release, this branch is used to publish "post-releases".
- `devel`: we add here new features and functionalities of the library that are going to appear in the next release of VCGLib. Bugfixes pushed in `main` are automatically merged on the `devel` branch.

Before submitting a PR, please check which branch suits better for your contribution!

### CLA

VCGLib is fully owned by CNR, and all the VCGLib contributors that do not work at the VCLab of CNR must first sign the contributor license agreement that you can find at the following link: https://github.com/cnr-isti-vclab/vcglib/blob/devel/docs/ContributorLicenseAgreement.pdf

If you will sign the CLA, then we will be able to merge your pull request after reviewing it.
The validity of the CLA is two years, therefore after signing it your PRs for the next two years can be merged without further actions.
Please send the signed document to muntoni.alessandro@gmail.com and paolo.cignoni@isti.cnr.it .
If you will not sign the CLA, we will review and then apply your changes as soon as possible.

Before opening the PR, please leave the following form with a check for your particular case:

##### Check with `[x]` what is your case:
- [ X ] I already signed and sent via email the CLA;
- [ ] I will sign and send the CLA via email as soon as possible;
- [ ] I don't want to sign the CLA.



This is a small patch to solve a coherence problem in the orientation of edges returned by the 
plane-triangle intersection method. 

The undesired behavior in the pre-patched code can be detected with the pymeshlab script
```python
import pymeshlab as ml
import numpy

ms = ml.MeshSet()
ms.apply_filter("create_sphere")
ms.generate_polyline_from_planar_section(planeaxis = 'Z Axis', planeoffset = 0)
m = ms.current_mesh()
m.compact()
print(m.edge_matrix().tolist() )
```

which give a list of edges like this

```txt
[[0, 1], [1, 3], [3, 4], [4, 12], [12, 10], [10, 9], [9, 11], [11, 13], [13, 14], [14, 15], [15, 16], 
[33, 32], [32, 31], [31, 30], [30, 28], [28, 26], [26, 27], [27, 29], [29, 21], [21, 20], [20, 18], 
[18, 17], [17, 19], [19, 22], [22, 23], [23, 24], [24, 25], [39, 40], [36, 40], [39, 38], [38, 25], 
[37, 36], [37, 35], [35, 34], [34, 8], [8, 7], [7, 6], [6, 5], [5, 2], [2, 0], [33, 45], [45, 46], [46, 47], 
[47, 43], [43, 44], [44, 42], [42, 41], [41, 16]]
```

Note that after [15, 16] there is a break in the chain of edges, and no edge in the sequence begins with index 16. 
Instead, there is two edges ending in 16 ( [15,16] and [41, 16] and also two edges beginning with index 37, 
revealing that some edges does not maintain the orientation of the triangles in the input mesh. 
This may be a problem for methods using this data and confused the user that did the question 
https://github.com/cnr-isti-vclab/PyMeshLab/discussions/235

After the patch, we obtain a perfect chain of edges which forms a closed loop of edges.
