### PR TITLE
Fix small bug in check

### DIFF
--- a/vcg/complex/algorithms/update/curvature.h
+++ b/vcg/complex/algorithms/update/curvature.h
@@ -475,7 +475,7 @@ static void MeanAndGaussian(MeshType & m)
     angle2 = M_PI-(angle0+angle1);
 
     // Skip degenerate triangles.
-    if(angle0==0 || angle1==0 || angle1==0) continue;
+    if(angle0==0 || angle1==0 || angle2==0) continue;
 
     e01v = ( (*fi).V(1)->cP() - (*fi).V(0)->cP() ) ;
     e12v = ( (*fi).V(2)->cP() - (*fi).V(1)->cP() ) ;


### PR DESCRIPTION
This PR fixes a small bug in a check for degenerate triangles.

##### Check with `[x]` what is your case:
- [x] I already signed and sent via email the CLA;
- [ ] I will sign and send the CLA via email as soon as possible;
- [ ] I don't want to sign the CLA.
