### PR TITLE
Intersection fixes

### DIFF
--- a/vcg/complex/algorithms/intersection.h
+++ b/vcg/complex/algorithms/intersection.h
@@ -256,78 +256,49 @@ bool Intersection(Plane3<ScalarType>  pl,
 	 Computes the intersection between a Ray and a Mesh. Returns a 3D Pointset.  
 */
 template < typename  TriMeshType, class ScalarType>
-bool IntersectionRayMesh(	
-	/* Input Mesh */		TriMeshType * m, 
-	/* Ray */				const Line3<ScalarType> & ray,
-	/* Intersect Point */	Point3<ScalarType> & hitPoint)
+bool IntersectionRayMesh(
+	/* Input Mesh */		 const TriMeshType& mesh,
+	/* Ray */				 const Ray3<ScalarType>& ray,
+	/* Intersect Point */	 Point3<ScalarType>& hitPoint
+	)
 {
-	//typedef typename TriMeshType::FaceContainer FaceContainer;
-	typename TriMeshType::FaceIterator fi;
-	bool hit=false;
-
-	if(m==0) return false;
-
-	//TriMeshType::FaceIterator fi;
-	//std::vector<TriMeshType::FaceType*>::iterator fi;
-
-	ScalarType bar1,bar2,dist;
-	Point3<ScalarType> p1;
-	Point3<ScalarType> p2;
-	Point3<ScalarType> p3;
-	for(fi = m->face.begin(); fi != m->face.end(); ++fi)
-	{
-		p1=vcg::Point3<ScalarType>( (*fi).P(0).X() ,(*fi).P(0).Y(),(*fi).P(0).Z() );
-		p2=vcg::Point3<ScalarType>( (*fi).P(1).X() ,(*fi).P(1).Y(),(*fi).P(1).Z() );
-		p3=vcg::Point3<ScalarType>( (*fi).P(2).X() ,(*fi).P(2).Y(),(*fi).P(2).Z() );
-		if(IntersectionLineTriangle<ScalarType>(ray,p1,p2,p3,dist,bar1,bar2))
-		{
-			hitPoint= p1*(1-bar1-bar2) + p2*bar1 + p3*bar2;
-			hit=true;
-		}
-	}
-
-	return hit;
+	ScalarType bar1, bar2, bar3;
+	typename TriMeshType::ConstFacePointer& fp;
+	return IntersectionRayMesh(mesh, ray, hitPoint, bar1, bar2, bar3, fp);
 }
 
 /** 
-	 Computes the intersection between a Ray and a Mesh. Returns a 3D Pointset, baricentric's coordinates 
-	 and a pointer of intersected face.
+	 Computes the intersection between a Ray and a Mesh. Returns the ray hit point,
+	 baricentric's coordinates and a pointer to the intersected face.
 */
-template < typename  TriMeshType, class ScalarType>
-bool IntersectionRayMesh(	
-	/* Input Mesh */		TriMeshType * m, 
-	/* Ray */				const Line3<ScalarType> & ray,
-	/* Intersect Point */	Point3<ScalarType> & hitPoint,
-	/* Baricentric coord 1*/ ScalarType &bar1,
-	/* Baricentric coord 2*/ ScalarType &bar2,
-	/* Baricentric coord 3*/ ScalarType &bar3,
-	/* FacePointer */ typename TriMeshType::FacePointer & fp
+template <typename TriMeshType, class ScalarType>
+bool IntersectionRayMesh(
+	/* Input Mesh */		 const TriMeshType& mesh,
+	/* Ray */				 const Ray3<ScalarType>& ray,
+	/* Intersect Point */	 Point3<ScalarType>& hitPoint,
+	/* Baricentric coord 1*/ ScalarType& bar1,
+	/* Baricentric coord 2*/ ScalarType& bar2,
+	/* Baricentric coord 3*/ ScalarType& bar3,
+	/* FacePointer */        typename TriMeshType::ConstFacePointer& fp
 	)
 {
-	//typedef typename TriMeshType::FaceContainer FaceContainer;
-	typename TriMeshType::FaceIterator fi;
-	bool hit=false;
-
-	if(m==0) return false;
-
-	//TriMeshType::FaceIterator fi;
-	//std::vector<TriMeshType::FaceType*>::iterator fi;
+	bool hit = false;
 
 	ScalarType dist;
 	Point3<ScalarType> p1;
 	Point3<ScalarType> p2;
 	Point3<ScalarType> p3;
-	for(fi = m->face.begin(); fi != m->face.end(); ++fi)
+	for(auto fi = mesh.face.cbegin(); fi != mesh.face.cend(); ++fi)
 	{
-		p1=vcg::Point3<ScalarType>( (*fi).P(0).X() ,(*fi).P(0).Y(),(*fi).P(0).Z() );
-		p2=vcg::Point3<ScalarType>( (*fi).P(1).X() ,(*fi).P(1).Y(),(*fi).P(1).Z() );
-		p3=vcg::Point3<ScalarType>( (*fi).P(2).X() ,(*fi).P(2).Y(),(*fi).P(2).Z() );
-		if(IntersectionLineTriangle<ScalarType>(ray,p1,p2,p3,dist,bar1,bar2))
+		p1 = Point3<ScalarType>( (*fi).P(0).X() ,(*fi).P(0).Y(),(*fi).P(0).Z() );
+		p2 = Point3<ScalarType>( (*fi).P(1).X() ,(*fi).P(1).Y(),(*fi).P(1).Z() );
+		p3 = Point3<ScalarType>( (*fi).P(2).X() ,(*fi).P(2).Y(),(*fi).P(2).Z() );
+		if( IntersectionRayTriangle<ScalarType>(ray, p1, p2, p3, dist, bar1, bar2) )
 		{
-			bar3 = (1-bar1-bar2);
-			hitPoint= p1*bar3 + p2*bar1 + p3*bar2;
+			bar3 = (1 - bar1 - bar2);
+			hitPoint = p1*bar3 + p2*bar1 + p3*bar2;
 			fp = &(*fi);
-			hit=true;
+			hit = true;
 		}
 	}
 

--- a/vcg/complex/algorithms/intersection.h
+++ b/vcg/complex/algorithms/intersection.h
@@ -263,7 +263,7 @@ bool IntersectionRayMesh(
 	)
 {
 	ScalarType bar1, bar2, bar3;
-	typename TriMeshType::ConstFacePointer& fp;
+	typename TriMeshType::ConstFacePointer fp;
 	return IntersectionRayMesh(mesh, ray, hitPoint, bar1, bar2, bar3, fp);
 }
 

--- a/vcg/space/intersection3.h
+++ b/vcg/space/intersection3.h
@@ -418,17 +418,33 @@ bool IntersectionLineTriangle( const Line3<T> & line, const Point3<T> & vert0,
    return 1;
 }
 
-template<class T>
-bool IntersectionRayTriangle( const Ray3<T> & ray, const Point3<T> & vert0,
-                  const Point3<T> & vert1, const Point3<T> & vert2,
-                  T & t ,T & u, T & v)
+/**
+     Computes the intersection between a Ray and a Triangle. Returns the hitDistance and the baricentric coordinates of the hit point.
+
+     bar3 = (1 - bar1 - bar2)
+     hitPoint = ray.origin + hitDistance * ray.direction = bar3 * vert0 + bar1 * vert1 + bar2 * vert2
+*/
+template<class ScalarType>
+bool IntersectionRayTriangle(
+    const Ray3<ScalarType>& ray,
+    const Point3<ScalarType>& vert0,
+    const Point3<ScalarType>& vert1,
+    const Point3<ScalarType>& vert2,
+    ScalarType& hitDistance,
+    ScalarType& bar1,
+    ScalarType& bar2)
 {
-    Line3<T> line(ray.Origin(), ray.Direction());
-    if (IntersectionLineTriangle(line, vert0, vert1, vert2, t, u, v))
-    {
-        if (t < 0) return 0;
-        else return 1;
-    }else return 0;
+    Line3<ScalarType> line(ray.Origin(), ray.Direction());
+    ScalarType new_hitDistance = hitDistance, new_bar1 = bar1, new_bar2 = bar2;
+    if ( IntersectionLineTriangle(line, vert0, vert1, vert2, new_hitDistance, new_bar1, new_bar2) ) {
+        if (t < 0) return false;
+        else {
+            hitDistance = new_hitDistance; bar1 = new_bar1; bar2 = new_bar2;
+            return true;
+        }
+    } else {
+        return false;
+    }
 }
 
 // line-box

--- a/vcg/space/intersection3.h
+++ b/vcg/space/intersection3.h
@@ -437,7 +437,7 @@ bool IntersectionRayTriangle(
     Line3<ScalarType> line(ray.Origin(), ray.Direction());
     ScalarType new_hitDistance = hitDistance, new_bar1 = bar1, new_bar2 = bar2;
     if ( IntersectionLineTriangle(line, vert0, vert1, vert2, new_hitDistance, new_bar1, new_bar2) ) {
-        if (t < 0) return false;
+        if (new_hitDistance < 0) return false;
         else {
             hitDistance = new_hitDistance; bar1 = new_bar1; bar2 = new_bar2;
             return true;


### PR DESCRIPTION
The most important change in this pull request, regarding the function IntersectRayMesh, is that the function will not return anymore intersections with faces which are opposite from the ray direction. This bug generally happens when the ray origin is inside the mesh.
The following are the details:

The functions IntersectRayMesh (available in vcg/complex/algorithms/intersect.h) are changed:
- Their signature is changed, now accepting a const mesh reference instead of a (non const) mesh pointer.
- The functions also accept a Ray3 instead of a Line3.
- Internally, the functions call IntersectRayTriangle instead of IntersectLineTriangle, which should not return anymore itersections opposite to the original ray direction.
- To prevent code duplication, the less specialized of the two functions calls the other one.

Additionally the function IntersectRayTriangle (available in vcg/space/intersection3.h) is changed:
- The signature is untouched, just renamed the variables for clarity.
- When calling IntersectLineTriangle but the intersect distance is negative (meaning the ray hit opposite to its direction) the output parameters are unchanged, effectively removing side effects when the functions returns false.

**CLA - Check with [x] what is your case:**
- [x] I already signed and sent via email the CLA;
- [ ] I will sign and send the CLA via email as soon as possible;
- [ ] I don't want to sign the CLA.
