### PR TITLE
Fix bug in export_ply.h

### DIFF
--- a/wrap/io_trimesh/export_ply.h
+++ b/wrap/io_trimesh/export_ply.h
@@ -752,6 +752,7 @@ public:
 									fwrite(&thp3df[i][fp][0], sizeof(double), 1,fpout);
 									fwrite(&thp3df[i][fp][1], sizeof(double), 1,fpout);
 									fwrite(&thp3df[i][fp][2], sizeof(double), 1,fpout);
+									break;
 								default : assert(0);
 								}
 							}


### PR DESCRIPTION
Without the `break` control flows into an `assert` in debug mode.

The emailed CLA process adds friction that I'm not willing to eat for a drive-by bug fix. I hope you are still able to land this simple, one-line, bug-fix change.

##### Check with `[x]` what is your case:
- [ ] I already signed and sent via email the CLA;
- [ ] I will sign and send the CLA via email as soon as possible;
- [ X ] I don't want to sign the CLA.

