### PR TITLE
fix face area weighting in quadric edge collapse

### DIFF
--- a/vcg/complex/algorithms/local_optimization/tri_edge_collapse_quadric.h
+++ b/vcg/complex/algorithms/local_optimization/tri_edge_collapse_quadric.h
@@ -566,13 +566,17 @@ public:
         if((*fi).V(0)->IsR() &&(*fi).V(1)->IsR() &&(*fi).V(2)->IsR())
         {
           Plane3<ScalarType,false> facePlane;
-          facePlane.SetDirection( ( (*fi).V(1)->cP() - (*fi).V(0)->cP() ) ^  ( (*fi).V(2)->cP() - (*fi).V(0)->cP() ));
-          if(!pp->UseArea)
-            facePlane.Normalize();
+          const Point3<ScalarType> dirArea = ( (*fi).V(1)->cP() - (*fi).V(0)->cP() ) ^ ( (*fi).V(2)->cP() - (*fi).V(0)->cP() );
+          facePlane.SetDirection(dirArea);
+          facePlane.Normalize();
+          const ScalarType area = dirArea.Norm();
           facePlane.SetOffset( facePlane.Direction().dot((*fi).V(0)->cP()));                   
 
           QuadricType q;
-          q.ByPlane(facePlane);          
+          q.ByPlane(facePlane);    
+          if (pp->UseArea) {
+            q *= area;
+          }      
           
           // The basic < add face quadric to each vertex > loop
           for(int j=0;j<3;++j)


### PR DESCRIPTION
## Thank you for sending a Pull Request to the VCGLib!

##### Check with `[x]` what is your case:
- [x] I already signed and sent via email the CLA;
- [ ] I will sign and send the CLA via email as soon as possible;
- [ ] I don't want to sign the CLA.

I think there is a bug in the area weighting of quadric edge decimation. In the paper "Simplifying Surfaces with Color and Texture using Quadric Error Metrics" and "New Quadric Metric for Simplifying Meshes
with Appearance Attributes", they both mentioned that the area weighting should be appied on the matrix Q, meaning Q *= Area. 

But in the vcglib's implementation, the squared area is multiplied into Q. I think it's a mistake. The current code 
```c++
facePlane.SetDirection( ( (*fi).V(1)->cP() - (*fi).V(0)->cP() ) ^  ( (*fi).V(2)->cP() - (*fi).V(0)->cP() ));
```
will actually multiple the area into the unit normal vector. And this face normal vector is used to construct the matrix Q, where each component is squared, or multiplied to each other, therefore the squared area is incorrectly weighted into Q.

Here is an actual experiment:
In meshlab, we can take a sphere mesh and select half of its faces and do subdivision (Here I used midpoint subdivision three times)
<img width="706" alt="截屏2024-05-21 21 37 05" src="https://github.com/cnr-isti-vclab/vcglib/assets/6289981/b3793e92-bb60-48a5-a9e1-f04daf9f8626">
And we decimate the mesh to 10000 faces. In the current implementation, we will observe a non-uniform face size. It's because the area is incorrectly squared, and most face area area less than one. So the smaller face will have a incorrect even smaller weight, which make the algorithm think the smaller face should have fewer cost, therefore being decimated much more.

<img width="698" alt="截屏2024-05-21 21 50 21" src="https://github.com/cnr-isti-vclab/vcglib/assets/6289981/39dcd1ba-dc04-4779-9b01-75496a5a674e">

After this fix, it works correctly. All the faces are distributed uniformly.

<img width="706" alt="截屏2024-05-21 21 38 12" src="https://github.com/cnr-isti-vclab/vcglib/assets/6289981/2c11696d-bffc-4a06-b816-1c14dc929413">


