### PR TITLE
Fix: Updated deprecated QProcess::start() method

### DIFF
--- a/wrap/io_trimesh/export_u3d.h
+++ b/wrap/io_trimesh/export_u3d.h
@@ -135,20 +135,17 @@ private:
     static int InvokeConverter(const u3dparametersclasses::IDTFConverterParameters& par)
     {
         QProcess p;
-        QString convstring = par._converter_loc;
-        #if defined(Q_OS_WIN)
-        convstring =  "\""+convstring + "\" -en 1 -rzf 0 -pq "+QString::number(par.positionQuality)+" -input \"" + par._input_file + "\" -output \"" + par._output_file +"\"";
-        #else
-        QString mac_input=par._input_file;
-        QString mac_output=par._output_file;
-        //mac_input.replace(QString(" "),QString("\\ "));
-        //mac_output.replace(QString(" "),QString("\\ "));
-        convstring =       convstring + " -en 1 -rzf 0 -pq "+ QString::number(par.positionQuality)+" -input \"" + mac_input + "\" -output \"" + mac_output +"\"";
-        #endif
+        QString program = par._converter_loc;
+        QStringList arguments;
+
+        arguments << "-en" << "1" << "-rzf" << "0" << "-pq" << QString::number(par.positionQuality);
+        arguments << "-input" << par._input_file << "-output" << par._output_file;
+
+        QString convstring = program + " " + arguments.join(" ");
         //QMessageBox::warning(0, QString("Saving Log"), QString("Started conversion executable '%1'").arg(convstring));
         qDebug("Starting converter %s", qPrintable(convstring));
         p.setProcessChannelMode(QProcess::MergedChannels);
-        p.start(convstring);
+        p.start(program, arguments);
         //wait until the task has been completed
         bool t = p.waitForFinished(-1);
         if(!t) QMessageBox::warning(0, QString("Saving Error"), QString("Failed conversion executable '%1'").arg(convstring));


### PR DESCRIPTION
## Thank you for sending a Pull Request to the VCGLib!

The code was using the deprecated QProcess::start(QString) method which takes a single string containing both the program and its arguments. This has been replaced with the modern QProcess::start(QString, QStringList) API that separates the program path from its arguments.

### Check the PR branch!

On this repository, we keep two relevant branches:

- `main`: we keep here the **last release version of VCGLib**, with just bugfixes. In case of serious bugs caught after a release, this branch is used to publish "post-releases".
- `devel`: we add here new features and functionalities of the library that are going to appear in the next release of VCGLib. Bugfixes pushed in `main` are automatically merged on the `devel` branch.

Before submitting a PR, please check which branch suits better for your contribution!

### CLA

VCGLib is fully owned by CNR, and all the VCGLib contributors that do not work at the VCLab of CNR must first sign the contributor license agreement that you can find at the following link: https://github.com/cnr-isti-vclab/vcglib/blob/devel/docs/ContributorLicenseAgreement.pdf

If you will sign the CLA, then we will be able to merge your pull request after reviewing it.
The validity of the CLA is two years, therefore after signing it your PRs for the next two years can be merged without further actions.
Please send the signed document to muntoni.alessandro@gmail.com and paolo.cignoni@isti.cnr.it .
If you will not sign the CLA, we will review and then apply your changes as soon as possible.

Before opening the PR, please leave the following form with a check for your particular case:

##### Check with `[x]` what is your case:
- [ ] I already signed and sent via email the CLA;
- [X] I will sign and send the CLA via email as soon as possible;
- [ ] I don't want to sign the CLA.
