### PR TITLE
Clean Face user bit flags in CountNonManifoldEdgeFF

### DIFF
--- a/vcg/complex/algorithms/clean.h
+++ b/vcg/complex/algorithms/clean.h
@@ -1139,6 +1139,10 @@ public:
 					}
 			}
 		}
+
+		FaceType::DeleteBitFlag(nmfBit[2]);
+		FaceType::DeleteBitFlag(nmfBit[1]);
+		FaceType::DeleteBitFlag(nmfBit[0]);
 		return edgeCnt;
 	}
 


### PR DESCRIPTION
## Clean Face user bit flags in CountNonManifoldEdgeFF

Currently the Face flags allocated by CountNonManifoldEdgeFF method are not deallocated in the end of the function. It can lead to unexpected behavior when calling this method multiple times or in other scenarios.

I made a small fix where I delete bit flags at the end of the method.

### CLA

- [X] I already signed and sent via email the CLA;
- [ ] I will sign and send the CLA via email as soon as possible;
- [ ] I don't want to sign the CLA.
